### PR TITLE
Document Elasticsearch 6 requirement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -264,6 +264,8 @@ Note: see bellow how to create this mapping file `istexIds.all.gz`.
 
 ### Build the Elasticsearch index
 
+Elasticsearch 6 is required. It is not compatible with Elasticsearch >=7.
+
 A node.js utility under the subdirectory `matching/` is used to build the Elasticsearch index. It will take a couple of hours for the 100M crossref entries.
 
 #### Install and configure


### PR DESCRIPTION
I ran into an error similar to this when indexing: https://github.com/OSGeo/gdal/issues/1246

So, I assume it is only compatible with 6.x.