### PR TITLE
Fix 'biblio' lookup hang

### DIFF
--- a/lookup/src/main/java/com/scienceminer/lookup/storage/LookupEngine.java
+++ b/lookup/src/main/java/com/scienceminer/lookup/storage/LookupEngine.java
@@ -335,6 +335,9 @@ public class LookupEngine {
                     matchingDocument.setFinalJsonObject(s);
                     callback.accept(matchingDocument);
                 }
+            } else {
+                // got an exception; propagate it
+                callback.accept(matchingDocument);
             }
         });
     }


### PR DESCRIPTION
If this codepath gets an exception from the Elasticsearch query instead of matches (eg, there was a 404 no results returned to a valid query on a healthy cluster), biblio-glutton hung for a very long timeout (several minutes?). This patch passes through the exception immediately.

I'm not sure how this wasn't encountered by others... crossref.org seems to do fuzzier search matching, and maybe with the full crossref corpus loaded in glutton elasticsearch there was always a response?

Tests passed for me locally, and this fixed the problem I was encountering (with an elastic cluster with "only" a few million records populated).

A related issue is that GROBID seems to not have any timeout on biblio-glutton requests. It might be good to add a configurable timeout in GROBID for glutton requests so folks (developers/users) get a meaningful 500 error to help debug.

This is my first PR to this repository. This patch is pretty small, but I accept the license terms now for any future PRs as well.