### PR TITLE
Fix last batch not always being loaded into Elastic cluster

### DIFF
--- a/matching/main.js
+++ b/matching/main.js
@@ -407,13 +407,9 @@ function index(options) {
                     throw resp;
                 } else {
                     console.log('Completed crossref indexing.');
-                    next();
                 }
             });
-        } else {
-            next();
         }
-
         batch = [];
     });
 }


### PR DESCRIPTION
This is a change we made on our copy when seeding a new elastic cluster, it stops the error being thrown when script is finished.