### PR TITLE
Increased lmdb max size to 1TB

### DIFF
--- a/lookup/src/main/java/com/scienceminer/lookup/storage/StorageEnvFactory.java
+++ b/lookup/src/main/java/com/scienceminer/lookup/storage/StorageEnvFactory.java
@@ -30,7 +30,7 @@ public class StorageEnvFactory {
         }
 
         environment = Env.create()
-                .setMapSize(300L * 1024L * 1024L * 1024L)
+                .setMapSize(1024L * 1024L * 1024L * 1024L)
                 .setMaxReaders(configuration.getMaxAcceptedRequests())
                 .setMaxDbs(10)
                 .open(thePath, EnvFlags.MDB_NOTLS);


### PR DESCRIPTION
This solved issue #85 for me and stopped the LMDB to cap out at 300gb. 
Don't know if this has any side effects when using on smaller disks or if there's any performance penalty