### PR TITLE
Fix the record display from the elasticsearch index

### DIFF
--- a/src/main/java/com/scienceminer/glutton/storage/DataEngine.java
+++ b/src/main/java/com/scienceminer/glutton/storage/DataEngine.java
@@ -40,7 +40,7 @@ public class DataEngine {
 
         returnMap.put("Crossref Metadata stored size", String.valueOf(crossrefMetadataLookup.getSize()));
         returnMap.put("HAL Metadata stored size", String.valueOf(halLookup.getSize()));
-        returnMap.put("Total metadata indexed size", String.valueOf(crossrefMetadataLookup.getSize()));
+        returnMap.put("Total metadata indexed size", String.valueOf(metadataMatching.getSizeByIndexes()));
         returnMap.put("PMID size", String.valueOf(pmidLookup.getSize()));
         returnMap.put("ISTEX size", String.valueOf(istexLookup.getSize()));
         returnMap.put("DOI OA size", String.valueOf(oaDoiLookup.getSize()));


### PR DESCRIPTION
This PR fixes the retrieval of the number of indexed documents in `/service/data`. Since in future we might have multiple index, it displays the different index names. This could be also used for troubleshooting as the index name may not match between glutton and the elasticsearch. 