### PR TITLE
Retry and bound the bulk indexing of the loaded records

### DIFF
--- a/config/glutton.yml
+++ b/config/glutton.yml
@@ -30,6 +30,14 @@ elastic:
   #host: 192.168.1.30:9200
   index: glutton
   maxConnections: 20
+  # for the loading and update commands: seconds to wait for a connection and for the answer to a
+  # bulk of records. Elasticsearch takes more than the default 30s for a full bulk when it is busy,
+  # and a bulk that times out is retried, so keep this generous
+  connectTimeout: 30
+  socketTimeout: 120
+  # how many bulks of records are sent at the same time while loading. Beyond that the loading
+  # waits for Elasticsearch instead of piling up requests that would only time out
+  maxConcurrentBulks: 4
 
 # solr settings
 solr:

--- a/doc/Build-Databases.md
+++ b/doc/Build-Databases.md
@@ -132,7 +132,24 @@ crossrefLookup
 
 On the above example, the 5,472,493 rejected records correspond to all the DOI entries of type "components" (part of document), which are filtered out. 
 
-As a February 2024, we have for example 146,808,255 accepted crossref records and 8,015,190 rejected component records (last indexed date in dump file is 2024-02-02). 
+As a February 2024, we have for example 146,808,255 accepted crossref records and 8,015,190 rejected component records (last indexed date in dump file is 2024-02-02).
+
+##### Indexing while loading
+
+The records are indexed in Elasticsearch in bulks while they are stored, on a few threads of their
+own so the storing side is not held up. `maxConcurrentBulks` in the `elastic` block of the
+configuration is how many bulks are sent at the same time (4 by default); beyond that the loading
+waits for Elasticsearch rather than piling up requests. A bulk that gets no answer or that
+Elasticsearch rejects because it is busy is sent again a few times, with a growing pause, and a
+document Elasticsearch refuses for good is logged with its reason. `socketTimeout`, in the same
+block, is how long to wait for the answer to a bulk (120 seconds by default; the 30 seconds the
+client would use on its own is too short for a full bulk on a busy cluster).
+
+The `*_indexed_records` and `*_failed_indexed_records` counters in the metrics say how many
+records got into the index and how many did not. Records that could not be indexed are still in
+the storage: once Elasticsearch is healthy again, `./gradlew index` rebuilds the index from it.
+The loading commands wait for the last bulks before they exit, so the two counters are final in
+the summary printed at the end. 
 
 #### CrossRef metadata gap coverage
 

--- a/src/main/java/com/scienceminer/glutton/command/LoadCrossrefCommand.java
+++ b/src/main/java/com/scienceminer/glutton/command/LoadCrossrefCommand.java
@@ -13,6 +13,7 @@ import com.scienceminer.glutton.storage.StorageEnvFactory;
 import com.scienceminer.glutton.storage.lookup.CrossrefMetadataLookup;
 import com.scienceminer.glutton.utils.io.DataSource;
 import com.scienceminer.glutton.utils.io.InputLocation;
+import com.scienceminer.glutton.indexing.ElasticSearchAsyncIndexer;
 import com.scienceminer.glutton.indexing.ElasticSearchIndexer;
 import io.dropwizard.core.cli.ConfiguredCommand;
 import io.dropwizard.core.setup.Bootstrap;
@@ -107,8 +108,15 @@ public class LoadCrossrefCommand extends ConfiguredCommand<LookupConfiguration> 
             }
         }
 
+        // the bulks still in flight would be lost by the exit below
+        LOGGER.info("Waiting for the last records to be indexed...");
+        ElasticSearchAsyncIndexer.getInstance(configuration).awaitPending();
+        ElasticSearchIndexer.getInstance(configuration).refreshIndex(configuration.getElastic().getIndex());
+
         LOGGER.info("Number of Crossref records processed: " + meter.getCount());
         LOGGER.info("Crossref lookup size " + metadataLookup.getSize() + " records.");
+        LOGGER.info("Crossref records indexed: " + counterIndexedRecords.getCount()
+                + ", not indexed: " + counterFailedIndexedRecords.getCount() + ".");
         if (metadataLookup.getLastIndexed() != null) {
             LOGGER.info("Crossref latest indexed date " + metadataLookup.getLastIndexed().toString() + ".");
         }

--- a/src/main/java/com/scienceminer/glutton/command/LoadHALCommand.java
+++ b/src/main/java/com/scienceminer/glutton/command/LoadHALCommand.java
@@ -8,6 +8,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.scienceminer.glutton.configuration.LookupConfiguration;
 import com.scienceminer.glutton.storage.StorageEnvFactory;
 import com.scienceminer.glutton.storage.lookup.HALLookup;
+import com.scienceminer.glutton.indexing.ElasticSearchAsyncIndexer;
 import com.scienceminer.glutton.indexing.ElasticSearchIndexer;
 import io.dropwizard.core.cli.ConfiguredCommand;
 import io.dropwizard.core.setup.Bootstrap;
@@ -65,7 +66,14 @@ public class LoadHALCommand extends ConfiguredCommand<LookupConfiguration> {
 
         halLookup.loadFromHALAPI(meter, counterInvalidRecords, counterIndexedRecords, counterFailedIndexedRecords);
 
+        // the bulks still in flight would be lost by the exit below
+        LOGGER.info("Waiting for the last records to be indexed...");
+        ElasticSearchAsyncIndexer.getInstance(configuration).awaitPending();
+        ElasticSearchIndexer.getInstance(configuration).refreshIndex(configuration.getElastic().getIndex());
+
         LOGGER.info("HAL loaded " + halLookup.getSize() + " records. ");
+        LOGGER.info("HAL records indexed: " + counterIndexedRecords.getCount()
+                + ", not indexed: " + counterFailedIndexedRecords.getCount() + ".");
 
         LOGGER.info("Finished in " +
                 TimeUnit.SECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS) + " s");

--- a/src/main/java/com/scienceminer/glutton/configuration/LookupConfiguration.java
+++ b/src/main/java/com/scienceminer/glutton/configuration/LookupConfiguration.java
@@ -6,6 +6,7 @@ import io.dropwizard.client.HttpClientConfiguration;
 import io.dropwizard.core.Configuration;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.io.File;
@@ -26,6 +27,7 @@ public class LookupConfiguration extends Configuration {
 
     private String searchEngine;
 
+    @Valid
     private Elastic elastic;
 
     private Solr solr;
@@ -201,6 +203,18 @@ public class LookupConfiguration extends Configuration {
         private String index;
         private int maxConnections = 10;
 
+        // the clients that index (dump load, gap and daily updates): how long to wait for the
+        // connection, and for the answer to a bulk, in seconds. A bulk of thousands of records on
+        // a busy cluster takes longer than the 30s the client waits by default.
+        @Min(1)
+        private int connectTimeout = 30;
+        @Min(1)
+        private int socketTimeout = 120;
+        // how many bulks are sent to Elasticsearch at the same time while loading; beyond that,
+        // the storing side waits rather than piling up requests
+        @Min(1)
+        private int maxConcurrentBulks = 4;
+
         public String getHost() {
             return host;
         }
@@ -223,6 +237,30 @@ public class LookupConfiguration extends Configuration {
 
         public void setMaxConnections(int maxConnections) {
             this.maxConnections = maxConnections;
+        }
+
+        public int getConnectTimeout() {
+            return connectTimeout;
+        }
+
+        public void setConnectTimeout(int connectTimeout) {
+            this.connectTimeout = connectTimeout;
+        }
+
+        public int getSocketTimeout() {
+            return socketTimeout;
+        }
+
+        public void setSocketTimeout(int socketTimeout) {
+            this.socketTimeout = socketTimeout;
+        }
+
+        public int getMaxConcurrentBulks() {
+            return maxConcurrentBulks;
+        }
+
+        public void setMaxConcurrentBulks(int maxConcurrentBulks) {
+            this.maxConcurrentBulks = maxConcurrentBulks;
         }
     }
 

--- a/src/main/java/com/scienceminer/glutton/configuration/LookupConfiguration.java
+++ b/src/main/java/com/scienceminer/glutton/configuration/LookupConfiguration.java
@@ -6,6 +6,7 @@ import io.dropwizard.client.HttpClientConfiguration;
 import io.dropwizard.core.Configuration;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -199,16 +200,22 @@ public class LookupConfiguration extends Configuration {
     
     public class Elastic {
 
+        /** The largest number of seconds that still fits an int once in milliseconds. */
+        public static final int MAX_TIMEOUT_SECONDS = Integer.MAX_VALUE / 1000;
+
         private String host;
         private String index;
         private int maxConnections = 10;
 
         // the clients that index (dump load, gap and daily updates): how long to wait for the
         // connection, and for the answer to a bulk, in seconds. A bulk of thousands of records on
-        // a busy cluster takes longer than the 30s the client waits by default.
+        // a busy cluster takes longer than the 30s the client waits by default. The client takes
+        // milliseconds as an int, hence the upper bound.
         @Min(1)
+        @Max(MAX_TIMEOUT_SECONDS)
         private int connectTimeout = 30;
         @Min(1)
+        @Max(MAX_TIMEOUT_SECONDS)
         private int socketTimeout = 120;
         // how many bulks are sent to Elasticsearch at the same time while loading; beyond that,
         // the storing side waits rather than piling up requests

--- a/src/main/java/com/scienceminer/glutton/indexing/BulkRetry.java
+++ b/src/main/java/com/scienceminer/glutton/indexing/BulkRetry.java
@@ -36,10 +36,17 @@ final class BulkRetry {
     static final class IndexOperation {
         final String id;
         final MetadataObj document;
+        /** Leave a document already in the index as it is, instead of replacing it. */
+        final boolean createOnly;
 
         IndexOperation(String id, MetadataObj document) {
+            this(id, document, false);
+        }
+
+        IndexOperation(String id, MetadataObj document, boolean createOnly) {
             this.id = id;
             this.document = document;
+            this.createOnly = createOnly;
         }
     }
 
@@ -50,8 +57,14 @@ final class BulkRetry {
 
     /** How a bulk ended, once nothing is left to retry. */
     static final class Outcome {
+        /** Taken by Elasticsearch. */
         int indexed;
+        /** Already in the index and left as they were, when asked not to replace. */
+        int skipped;
+        /** Refused for good: Elasticsearch answered and said no. Sending them again would not help. */
         int failed;
+        /** Never got through: Elasticsearch did not answer, or could not take them, as many times as asked. */
+        int unsent;
     }
 
     private final BulkSender sender;
@@ -103,14 +116,15 @@ final class BulkRetry {
             LOGGER.error("Giving up on " + remaining.size() + " document(s) after " + MAX_ATTEMPTS
                     + " attempts, they will not be indexed. Reindex the storage with the index command "
                     + "once Elasticsearch is healthy.");
-            outcome.failed += remaining.size();
+            outcome.unsent += remaining.size();
         }
         return outcome;
     }
 
     /**
      * Goes through the answer item by item: acknowledged documents are counted, refused ones are
-     * counted and logged, rejected ones are handed back to be sent again.
+     * counted and logged, rejected ones are handed back to be sent again. A document that was
+     * not to be replaced and is already there is neither a failure nor something to send again.
      */
     private static List<IndexOperation> sortItems(List<IndexOperation> sent, BulkResponse response, Outcome outcome) {
         List<BulkResponseItem> items = response.items();
@@ -128,6 +142,9 @@ final class BulkRetry {
             BulkResponseItem item = items.get(i);
             if (item.error() == null) {
                 outcome.indexed++;
+            } else if (sent.get(i).createOnly && item.status() == 409) {
+                // the document is there already and was to be left alone: that is what was asked
+                outcome.skipped++;
             } else if (isRetriable(item.status()) || isRejectedExecution(item)) {
                 rejected.add(sent.get(i));
             } else {

--- a/src/main/java/com/scienceminer/glutton/indexing/BulkRetry.java
+++ b/src/main/java/com/scienceminer/glutton/indexing/BulkRetry.java
@@ -1,0 +1,161 @@
+package com.scienceminer.glutton.indexing;
+
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Sends one bulk of documents to Elasticsearch and retries what did not get through.
+ *
+ * A bulk can fail as a whole (the connection dropped, the request timed out, the cluster answered
+ * 429 or 503) or item by item (Elasticsearch takes the request but rejects some documents, most
+ * often because its write queue is full). Both cases are transient more often than not during a
+ * load, so the whole bulk, or only the rejected items, are sent again after a growing pause.
+ * Indexing a document is idempotent - the id is the record identifier - so resending is safe.
+ *
+ * A document Elasticsearch refuses for good (a mapping error, say) is not sent again: it is
+ * counted as failed and the reason is logged.
+ */
+final class BulkRetry {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BulkRetry.class);
+
+    static final int MAX_ATTEMPTS = 5;
+    static final long FIRST_BACKOFF_MS = 2000;
+    /** How many refused documents get their reason logged per bulk, so a bad batch does not flood the log. */
+    private static final int MAX_LOGGED_REASONS = 5;
+
+    /** One document to index, kept apart from the bulk so a rejected item can be sent again on its own. */
+    static final class IndexOperation {
+        final String id;
+        final MetadataObj document;
+
+        IndexOperation(String id, MetadataObj document) {
+            this.id = id;
+            this.document = document;
+        }
+    }
+
+    /** The Elasticsearch call, behind an interface so the retry behaviour can be tested without a cluster. */
+    interface BulkSender {
+        BulkResponse send(List<IndexOperation> operations) throws IOException;
+    }
+
+    /** How a bulk ended, once nothing is left to retry. */
+    static final class Outcome {
+        int indexed;
+        int failed;
+    }
+
+    private final BulkSender sender;
+    private final long firstBackoffMs;
+
+    BulkRetry(BulkSender sender) {
+        this(sender, FIRST_BACKOFF_MS);
+    }
+
+    BulkRetry(BulkSender sender, long firstBackoffMs) {
+        this.sender = sender;
+        this.firstBackoffMs = firstBackoffMs;
+    }
+
+    Outcome index(List<IndexOperation> operations) throws InterruptedException {
+        Outcome outcome = new Outcome();
+        List<IndexOperation> remaining = operations;
+
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS && !remaining.isEmpty(); attempt++) {
+            if (attempt > 1) {
+                TimeUnit.MILLISECONDS.sleep(firstBackoffMs << (attempt - 2));
+            }
+
+            BulkResponse response;
+            try {
+                response = sender.send(remaining);
+            } catch (IOException e) {
+                // no answer at all: the request timed out or the connection dropped
+                LOGGER.warn("Bulk indexing of " + remaining.size() + " document(s) got no answer from "
+                        + "Elasticsearch, attempt " + attempt + "/" + MAX_ATTEMPTS + ": " + e);
+                continue;
+            } catch (ElasticsearchException e) {
+                if (isRetriable(e.status())) {
+                    LOGGER.warn("Elasticsearch refused a bulk of " + remaining.size() + " document(s) with "
+                            + "HTTP " + e.status() + ", attempt " + attempt + "/" + MAX_ATTEMPTS + ": "
+                            + e.getMessage());
+                    continue;
+                }
+                LOGGER.error("Elasticsearch rejected a bulk of " + remaining.size() + " document(s) with HTTP "
+                        + e.status() + ", they will not be indexed: " + e.getMessage());
+                outcome.failed += remaining.size();
+                return outcome;
+            }
+
+            remaining = sortItems(remaining, response, outcome);
+        }
+
+        if (!remaining.isEmpty()) {
+            LOGGER.error("Giving up on " + remaining.size() + " document(s) after " + MAX_ATTEMPTS
+                    + " attempts, they will not be indexed. Reindex the storage with the index command "
+                    + "once Elasticsearch is healthy.");
+            outcome.failed += remaining.size();
+        }
+        return outcome;
+    }
+
+    /**
+     * Goes through the answer item by item: acknowledged documents are counted, refused ones are
+     * counted and logged, rejected ones are handed back to be sent again.
+     */
+    private static List<IndexOperation> sortItems(List<IndexOperation> sent, BulkResponse response, Outcome outcome) {
+        List<BulkResponseItem> items = response.items();
+        if (items.size() != sent.size()) {
+            // never seen, but if the answer cannot be paired with what was sent, guessing which
+            // documents got in would be worse than sending them all again
+            LOGGER.warn("Elasticsearch answered " + items.size() + " item(s) for a bulk of " + sent.size()
+                    + " document(s), sending the bulk again");
+            return sent;
+        }
+
+        List<IndexOperation> rejected = new ArrayList<>();
+        int loggedReasons = 0;
+        for (int i = 0; i < items.size(); i++) {
+            BulkResponseItem item = items.get(i);
+            if (item.error() == null) {
+                outcome.indexed++;
+            } else if (isRetriable(item.status()) || isRejectedExecution(item)) {
+                rejected.add(sent.get(i));
+            } else {
+                outcome.failed++;
+                if (loggedReasons < MAX_LOGGED_REASONS) {
+                    LOGGER.error("Elasticsearch refused document " + item.id() + " (HTTP " + item.status()
+                            + "): " + item.error().reason());
+                    loggedReasons++;
+                }
+            }
+        }
+        if (outcome.failed > loggedReasons && loggedReasons == MAX_LOGGED_REASONS) {
+            LOGGER.error("... and more documents were refused in the same bulk, only the first "
+                    + MAX_LOGGED_REASONS + " reasons are shown");
+        }
+        if (!rejected.isEmpty()) {
+            LOGGER.warn("Elasticsearch rejected " + rejected.size() + " of " + sent.size()
+                    + " document(s), they will be sent again");
+        }
+        return rejected;
+    }
+
+    /** The cluster is there but cannot take the request right now. */
+    static boolean isRetriable(int status) {
+        return status == 429 || status == 502 || status == 503 || status == 504;
+    }
+
+    private static boolean isRejectedExecution(BulkResponseItem item) {
+        return item.error() != null && "es_rejected_execution_exception".equals(item.error().type());
+    }
+}

--- a/src/main/java/com/scienceminer/glutton/indexing/ElasticSearchAsyncIndexer.java
+++ b/src/main/java/com/scienceminer/glutton/indexing/ElasticSearchAsyncIndexer.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Indexes batches of records in Elasticsearch off the thread that stores them, so the loading of
@@ -35,6 +36,15 @@ import java.util.concurrent.atomic.AtomicInteger;
  * until one is done: the storing side slows down to what Elasticsearch takes rather than piling
  * up requests that then time out. Each bulk is retried on transient failures, see
  * {@link BulkRetry}.
+ *
+ * With {@code update} false, a document already in the index is left as it is rather than
+ * replaced; with it true, the record sent wins. Either way the identifier is the record's, so
+ * sending a document twice is harmless.
+ *
+ * What could not be indexed is counted in two ways: {@code counterFailedIndexedRecords} takes
+ * every document that did not get in, whatever the reason, and {@link #getRecordsNotSent()}
+ * counts only those Elasticsearch never took because it was away or too busy - the ones a later
+ * run can bring in, as opposed to documents Elasticsearch refused for good.
  *
  * The threads are daemons, so a running service is never kept alive by them; a command must call
  * {@link #awaitPending()} before it exits, or the last bulks are lost.
@@ -53,6 +63,7 @@ public class ElasticSearchAsyncIndexer implements Closeable {
     private final ExecutorService executor;
     private final Semaphore slots;
     private final AtomicInteger pending = new AtomicInteger();
+    private final AtomicLong recordsNotSent = new AtomicLong();
     private final Object drained = new Object();
 
     public static ElasticSearchAsyncIndexer getInstance(LookupConfiguration configuration) {
@@ -112,13 +123,24 @@ public class ElasticSearchAsyncIndexer implements Closeable {
         BulkRequest.Builder br = new BulkRequest.Builder();
         String indexName = configuration.getElastic().getIndex();
         for (IndexOperation operation : operations) {
-            br.operations(op -> op
-                .index(idx -> idx
-                    .index(indexName)
-                    .id(operation.id)
-                    .document(operation.document)
-                )
-            );
+            if (operation.createOnly) {
+                // refused with a 409 when the document is there already, which is the point
+                br.operations(op -> op
+                    .create(c -> c
+                        .index(indexName)
+                        .id(operation.id)
+                        .document(operation.document)
+                    )
+                );
+            } else {
+                br.operations(op -> op
+                    .index(idx -> idx
+                        .index(indexName)
+                        .id(operation.id)
+                        .document(operation.document)
+                    )
+                );
+            }
         }
         return elasticsearchClient.bulk(br.build());
     }
@@ -146,7 +168,7 @@ public class ElasticSearchAsyncIndexer implements Closeable {
                 // counter here for records that failed to index
                 counterFailedIndexedRecords.inc();
             } else if (!MetadataObjBuilder.isFilteredType(objToIndex)) {
-                operations.add(toOperation(objToIndex));
+                operations.add(toOperation(objToIndex, update));
             }
         }
         submit(operations, counterIndexedRecords, counterFailedIndexedRecords);
@@ -160,17 +182,17 @@ public class ElasticSearchAsyncIndexer implements Closeable {
                 // counter here for records that failed to index
                 counterFailedIndexedRecords.inc();
             } else if (!MetadataObjBuilder.isFilteredType(objToIndex)) {
-                operations.add(toOperation(objToIndex));
+                operations.add(toOperation(objToIndex, update));
             }
         }
         submit(operations, counterIndexedRecords, counterFailedIndexedRecords);
     }
 
-    private static IndexOperation toOperation(MetadataObj objToIndex) {
+    private static IndexOperation toOperation(MetadataObj objToIndex, boolean update) {
         objToIndex.type = null;
         String localIdentifier = objToIndex._id;
         objToIndex._id = null;
-        return new IndexOperation(localIdentifier, objToIndex);
+        return new IndexOperation(localIdentifier, objToIndex, !update);
     }
 
     /**
@@ -186,7 +208,7 @@ public class ElasticSearchAsyncIndexer implements Closeable {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             logger.error("Interrupted while waiting to index " + operations.size() + " document(s), they will not be indexed");
-            counterFailedIndexedRecords.inc(operations.size());
+            notSent(operations.size(), counterFailedIndexedRecords);
             return;
         }
 
@@ -197,12 +219,16 @@ public class ElasticSearchAsyncIndexer implements Closeable {
                     Outcome outcome = bulkRetry.index(operations);
                     counterIndexedRecords.inc(outcome.indexed);
                     counterFailedIndexedRecords.inc(outcome.failed);
+                    notSent(outcome.unsent, counterFailedIndexedRecords);
+                    if (outcome.skipped > 0) {
+                        logger.debug(outcome.skipped + " document(s) already in the index were left as they were");
+                    }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    counterFailedIndexedRecords.inc(operations.size());
+                    notSent(operations.size(), counterFailedIndexedRecords);
                 } catch (RuntimeException e) {
                     logger.error("Batch indexing failed, " + operations.size() + " document(s) will not be indexed", e);
-                    counterFailedIndexedRecords.inc(operations.size());
+                    notSent(operations.size(), counterFailedIndexedRecords);
                 } finally {
                     slots.release();
                     bulkDone();
@@ -214,6 +240,23 @@ public class ElasticSearchAsyncIndexer implements Closeable {
             bulkDone();
             throw e;
         }
+    }
+
+    private void notSent(int count, Counter counterFailedIndexedRecords) {
+        if (count > 0) {
+            counterFailedIndexedRecords.inc(count);
+            recordsNotSent.addAndGet(count);
+        }
+    }
+
+    /**
+     * How many documents, since the start, Elasticsearch never took because it was away or too
+     * busy for as long as they were retried. Unlike the failed counter this leaves out the
+     * documents Elasticsearch refused for good, so a caller can tell an update cut short by an
+     * outage (worth doing again) from one with a few bad records in it (which is not).
+     */
+    public long getRecordsNotSent() {
+        return recordsNotSent.get();
     }
 
     private void bulkDone() {

--- a/src/main/java/com/scienceminer/glutton/indexing/ElasticSearchAsyncIndexer.java
+++ b/src/main/java/com/scienceminer/glutton/indexing/ElasticSearchAsyncIndexer.java
@@ -1,57 +1,59 @@
 package com.scienceminer.glutton.indexing;
 
-import java.io.*;
-import java.util.*;
-
-import com.scienceminer.glutton.configuration.LookupConfiguration;
-
-import co.elastic.clients.elasticsearch.*;
-import co.elastic.clients.elasticsearch.cluster.*;
-import co.elastic.clients.elasticsearch.core.*;
-import co.elastic.clients.transport.*;
-import org.elasticsearch.client.RestClient;
-import co.elastic.clients.elasticsearch.indices.*;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
-import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.transport.ElasticsearchTransport;
-import co.elastic.clients.transport.endpoints.*;
-import co.elastic.clients.elasticsearch.cat.IndicesResponse;
-import co.elastic.clients.elasticsearch.indices.ExistsRequest;
-import co.elastic.clients.elasticsearch.indices.RefreshRequest;
-import co.elastic.clients.elasticsearch.core.bulk.*;
-
-import com.fasterxml.jackson.databind.node.*;
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
-
-import com.scienceminer.glutton.exception.ServiceException;
-import com.scienceminer.glutton.exception.ServiceOverloadedException;
-import com.scienceminer.glutton.utils.BinarySerialiser;
-
-import org.apache.http.HttpHost;
-import org.apache.commons.io.FileUtils;
-
-import com.codahale.metrics.Meter;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.codahale.metrics.Counter;
-
-import org.lmdbjava.*;
-import java.nio.ByteBuffer;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.scienceminer.glutton.configuration.LookupConfiguration;
+import com.scienceminer.glutton.indexing.BulkRetry.IndexOperation;
+import com.scienceminer.glutton.indexing.BulkRetry.Outcome;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ElasticSearchAsyncIndexer {
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Indexes batches of records in Elasticsearch off the thread that stores them, so the loading of
+ * a dump or of the Crossref updates is not held up by the search index.
+ *
+ * Bulks run on a small pool of threads, {@code elastic.maxConcurrentBulks} at a time. When they
+ * are all busy and as many again are waiting, {@link #asyncIndexJsonObjects} blocks the caller
+ * until one is done: the storing side slows down to what Elasticsearch takes rather than piling
+ * up requests that then time out. Each bulk is retried on transient failures, see
+ * {@link BulkRetry}.
+ *
+ * The threads are daemons, so a running service is never kept alive by them; a command must call
+ * {@link #awaitPending()} before it exits, or the last bulks are lost.
+ */
+public class ElasticSearchAsyncIndexer implements Closeable {
     protected static final Logger logger = LoggerFactory.getLogger(ElasticSearchAsyncIndexer.class);
 
     private static volatile ElasticSearchAsyncIndexer instance;
 
-    private LookupConfiguration configuration;
-    private RestClient restClient;
-    private ElasticsearchTransport transport;
-    private ElasticsearchAsyncClient elasticsearchAsyncClient;
+    private final LookupConfiguration configuration;
+    private final RestClient restClient;
+    private final ElasticsearchTransport transport;
+    private final ElasticsearchClient elasticsearchClient;
 
-    private String settingsPath = "config/elastic-settings.json";
+    private final BulkRetry bulkRetry;
+    private final ExecutorService executor;
+    private final Semaphore slots;
+    private final AtomicInteger pending = new AtomicInteger();
+    private final Object drained = new Object();
 
     public static ElasticSearchAsyncIndexer getInstance(LookupConfiguration configuration) {
         if (instance == null) {
@@ -73,132 +75,175 @@ public class ElasticSearchAsyncIndexer {
 
     private ElasticSearchAsyncIndexer(LookupConfiguration configuration) {
         this.configuration = configuration;
+        LookupConfiguration.Elastic elastic = configuration.getElastic();
+        int concurrentBulks = elastic.getMaxConcurrentBulks();
 
-        // Create the low-level client
+        // Create the low-level client. A bulk of thousands of records takes longer than the 30s
+        // the client waits by default when the cluster is busy, and a timed-out bulk is a lost
+        // one, hence the configurable socket timeout.
         restClient = RestClient
-            .builder(HttpHost.create(configuration.getElastic().getHost()))
-            //.setDefaultHeaders(new Header[]{
-            //    new BasicHeader("Authorization", "ApiKey " + apiKey)
-            //})
+            .builder(HttpHost.create(elastic.getHost()))
+            .setRequestConfigCallback(requestConfig -> requestConfig
+                .setConnectTimeout((int) TimeUnit.SECONDS.toMillis(elastic.getConnectTimeout()))
+                .setSocketTimeout((int) TimeUnit.SECONDS.toMillis(elastic.getSocketTimeout())))
+            .setHttpClientConfigCallback(httpClient -> httpClient
+                .setMaxConnPerRoute(concurrentBulks)
+                .setMaxConnTotal(concurrentBulks))
             .build();
 
         // Create the transport with a Jackson mapper
-        transport = new RestClientTransport(
-            restClient, new JacksonJsonpMapper());
+        transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
 
         // And create the API client
-        elasticsearchAsyncClient = new ElasticsearchAsyncClient(transport);
+        elasticsearchClient = new ElasticsearchClient(transport);
+
+        bulkRetry = new BulkRetry(this::sendBulk);
+        // as many bulks waiting as running keeps the pool busy while the storing side is held back
+        slots = new Semaphore(2 * concurrentBulks);
+        AtomicInteger threadNumber = new AtomicInteger();
+        executor = Executors.newFixedThreadPool(concurrentBulks, runnable -> {
+            Thread thread = new Thread(runnable, "es-bulk-indexer-" + threadNumber.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    private BulkResponse sendBulk(List<IndexOperation> operations) throws IOException {
+        BulkRequest.Builder br = new BulkRequest.Builder();
+        String indexName = configuration.getElastic().getIndex();
+        for (IndexOperation operation : operations) {
+            br.operations(op -> op
+                .index(idx -> idx
+                    .index(indexName)
+                    .id(operation.id)
+                    .document(operation.document)
+                )
+            );
+        }
+        return elasticsearchClient.bulk(br.build());
     }
 
     /**
-     * Extend an existing index with a set of documents. The expected values are JSON 
-     * documents in the CrossRef format. 
-     * 
+     * Extend an existing index with a set of documents. The expected values are JSON
+     * documents in the CrossRef format.
+     *
      * Asynchronous version useful when combining processes of storing and indexing.
-     * 
-     * Document identifier is the source prefixed by the main identifier of the this source: 
-     * e.g. crossref:DOI, hal:HalID, pubmed:pmid 
-     * 
+     *
+     * Document identifier is the source prefixed by the main identifier of the this source:
+     * e.g. crossref:DOI, hal:HalID, pubmed:pmid
+     *
      * Already existing keys are skipt if update is false.
-     * 
+     *
      **/
-    public void asyncIndexDocuments(List<String> documents, 
-                                    boolean update, 
-                                    Counter counterIndexedRecords, 
+    public void asyncIndexDocuments(List<String> documents,
+                                    boolean update,
+                                    Counter counterIndexedRecords,
                                     Counter counterFailedIndexedRecords) {
-        BulkRequest.Builder br = new BulkRequest.Builder();
-        for(String document : documents) {
+        List<IndexOperation> operations = new ArrayList<>();
+        for (String document : documents) {
             MetadataObj objToIndex = MetadataObjBuilder.createMetadataObj(document);
-            if (objToIndex != null && !MetadataObjBuilder.isFilteredType(objToIndex)) {
-                objToIndex.type = null;
-                String localIdentifier = objToIndex._id;
-                objToIndex._id = null;
-                br.operations(op -> op           
-                    .index(idx -> idx            
-                        .index(configuration.getElastic().getIndex())       
-                        .id(localIdentifier)
-                        .document(objToIndex)
-                    )
-                );
-            } 
-
             if (objToIndex == null) {
                 // counter here for records that failed to index
                 counterFailedIndexedRecords.inc();
+            } else if (!MetadataObjBuilder.isFilteredType(objToIndex)) {
+                operations.add(toOperation(objToIndex));
             }
         }
-
-        try {
-            this.elasticsearchAsyncClient.bulk(
-                br.build()
-            ).whenComplete((response, exception) -> {
-                if (exception != null) {
-                    logger.error("Batch indexing failed", exception);
-                } else {
-                    counterIndexedRecords.inc(documents.size());
-                }
-
-                if (response.errors()) {
-                    logger.error("Bulk had errors");
-                    for (BulkResponseItem item: response.items()) {
-                        if (item.error() != null) {
-                            logger.error(item.error().reason());
-                        }
-                    }
-                }
-            });
-            
-        } catch (Exception e) {
-            logger.error("Batch indexing failed", e);
-        }
+        submit(operations, counterIndexedRecords, counterFailedIndexedRecords);
     }
 
     public void asyncIndexJsonObjects(List<JsonNode> documents, boolean update, Counter counterIndexedRecords, Counter counterFailedIndexedRecords) {
-        BulkRequest.Builder br = new BulkRequest.Builder();
-        for(JsonNode document : documents) {
+        List<IndexOperation> operations = new ArrayList<>();
+        for (JsonNode document : documents) {
             MetadataObj objToIndex = MetadataObjBuilder.createMetadataObjFromJsonNode(document);
-            if (objToIndex != null && !MetadataObjBuilder.isFilteredType(objToIndex)) {
-                objToIndex.type = null;
-                String localIdentifier = objToIndex._id;
-                objToIndex._id = null;
-                br.operations(op -> op           
-                    .index(idx -> idx            
-                        .index(configuration.getElastic().getIndex())       
-                        .id(localIdentifier)
-                        .document(objToIndex)
-                    )
-                );
-            } 
-
             if (objToIndex == null) {
                 // counter here for records that failed to index
                 counterFailedIndexedRecords.inc();
+            } else if (!MetadataObjBuilder.isFilteredType(objToIndex)) {
+                operations.add(toOperation(objToIndex));
             }
         }
+        submit(operations, counterIndexedRecords, counterFailedIndexedRecords);
+    }
 
+    private static IndexOperation toOperation(MetadataObj objToIndex) {
+        objToIndex.type = null;
+        String localIdentifier = objToIndex._id;
+        objToIndex._id = null;
+        return new IndexOperation(localIdentifier, objToIndex);
+    }
+
+    /**
+     * Queues one bulk. Returns at once unless the pool and its waiting line are full, in which
+     * case the caller is held until a bulk completes.
+     */
+    private void submit(List<IndexOperation> operations, Counter counterIndexedRecords, Counter counterFailedIndexedRecords) {
+        if (operations.isEmpty()) {
+            return;
+        }
         try {
-            this.elasticsearchAsyncClient.bulk(
-                br.build()
-            ).whenComplete((response, exception) -> {
-                if (exception != null) {
-                    logger.error("Batch indexing failed", exception);
-                } else {
-                    counterIndexedRecords.inc(documents.size());
-                }
+            slots.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Interrupted while waiting to index " + operations.size() + " document(s), they will not be indexed");
+            counterFailedIndexedRecords.inc(operations.size());
+            return;
+        }
 
-                if (response.errors()) {
-                    logger.error("Bulk had errors");
-                    for (BulkResponseItem item: response.items()) {
-                        if (item.error() != null) {
-                            logger.error(item.error().reason());
-                        }
-                    }
+        pending.incrementAndGet();
+        try {
+            executor.execute(() -> {
+                try {
+                    Outcome outcome = bulkRetry.index(operations);
+                    counterIndexedRecords.inc(outcome.indexed);
+                    counterFailedIndexedRecords.inc(outcome.failed);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    counterFailedIndexedRecords.inc(operations.size());
+                } catch (RuntimeException e) {
+                    logger.error("Batch indexing failed, " + operations.size() + " document(s) will not be indexed", e);
+                    counterFailedIndexedRecords.inc(operations.size());
+                } finally {
+                    slots.release();
+                    bulkDone();
                 }
             });
-            
-        } catch (Exception e) {
-            logger.error("Batch indexing failed", e);
+        } catch (RuntimeException e) {
+            // the executor refused the task, so its finally block never runs
+            slots.release();
+            bulkDone();
+            throw e;
         }
     }
 
+    private void bulkDone() {
+        if (pending.decrementAndGet() == 0) {
+            synchronized (drained) {
+                drained.notifyAll();
+            }
+        }
+    }
+
+    /** Number of bulks queued or being sent. */
+    public int getPendingBulks() {
+        return pending.get();
+    }
+
+    /**
+     * Blocks until every bulk queued so far has been sent, retried or given up on. To be called
+     * before a loading command exits, and before the index is refreshed to check its size.
+     */
+    public void awaitPending() throws InterruptedException {
+        synchronized (drained) {
+            while (pending.get() > 0) {
+                drained.wait(500);
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        executor.shutdown();
+        transport.close();
+    }
 }

--- a/src/main/java/com/scienceminer/glutton/indexing/ElasticSearchIndexer.java
+++ b/src/main/java/com/scienceminer/glutton/indexing/ElasticSearchIndexer.java
@@ -2,6 +2,7 @@ package com.scienceminer.glutton.indexing;
 
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import com.scienceminer.glutton.configuration.LookupConfiguration;
 
@@ -70,9 +71,14 @@ public class ElasticSearchIndexer {
     private ElasticSearchIndexer(LookupConfiguration configuration) {
         this.configuration = configuration;
 
-        // Create the low-level client
+        // Create the low-level client, waiting for a bulk as long as configured rather than the
+        // 30s default, which a full bulk on a busy cluster easily exceeds
+        LookupConfiguration.Elastic elastic = configuration.getElastic();
         restClient = RestClient
-            .builder(HttpHost.create(configuration.getElastic().getHost()))
+            .builder(HttpHost.create(elastic.getHost()))
+            .setRequestConfigCallback(requestConfig -> requestConfig
+                .setConnectTimeout((int) TimeUnit.SECONDS.toMillis(elastic.getConnectTimeout()))
+                .setSocketTimeout((int) TimeUnit.SECONDS.toMillis(elastic.getSocketTimeout())))
             //.setDefaultHeaders(new Header[]{
             //    new BasicHeader("Authorization", "ApiKey " + apiKey)
             //})

--- a/src/main/java/com/scienceminer/glutton/utils/crossrefclient/IncrementalLoaderTask.java
+++ b/src/main/java/com/scienceminer/glutton/utils/crossrefclient/IncrementalLoaderTask.java
@@ -15,6 +15,7 @@ import com.scienceminer.glutton.storage.StorageEnvFactory;
 import com.scienceminer.glutton.utils.openalex.OpenAccessUpdater;
 import com.scienceminer.glutton.configuration.LookupConfiguration;
 import com.scienceminer.glutton.reader.CrossrefJsonlReader;
+import com.scienceminer.glutton.indexing.ElasticSearchAsyncIndexer;
 
 import java.util.*;
 import java.io.*;
@@ -253,6 +254,9 @@ public class IncrementalLoaderTask implements Runnable {
             while(isChanging) {
                 try {
                     TimeUnit.SECONDS.sleep(5);
+                    // the bulks queued so far, with their retries, must be through before the
+                    // index size means anything
+                    ElasticSearchAsyncIndexer.getInstance(configuration).awaitPending();
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                 }

--- a/src/main/java/com/scienceminer/glutton/utils/crossrefclient/IncrementalLoaderTask.java
+++ b/src/main/java/com/scienceminer/glutton/utils/crossrefclient/IncrementalLoaderTask.java
@@ -144,6 +144,11 @@ public class IncrementalLoaderTask implements Runnable {
             openAccessMeter,
             counterDroppedOpenAccess);
 
+        // one thread storing the files as they come, and every task kept so the run can wait for
+        // them: the files must not be cleaned up while a loader still needs one
+        ExecutorService executorLoading = Executors.newSingleThreadExecutor();
+        List<Future<?>> loadingTasks = new ArrayList<>();
+
         try {
 
         while(!responseEmpty) {
@@ -207,10 +212,9 @@ public class IncrementalLoaderTask implements Runnable {
             } 
 
             // load in another thread
-            ExecutorService executorLoading = Executors.newSingleThreadExecutor();
             Runnable taskLoading = new LoadCrossrefFile(crossrefFile, 
                 jsonObjectsStr, this.configuration, meter, counterInvalidRecords, counterIndexedRecords, counterFailedIndexedRecords);
-            executorLoading.submit(taskLoading);
+            loadingTasks.add(executorLoading.submit(taskLoading));
 
             // resolved on its own thread, so the Crossref fetching is not held up by OpenAlex
             openAccessUpdater.submit(jsonObjectsStr);
@@ -229,6 +233,18 @@ public class IncrementalLoaderTask implements Runnable {
         }
 
         } finally {
+            // every file fetched is stored before anything else happens to it
+            executorLoading.shutdown();
+            for (Future<?> loadingTask : loadingTasks) {
+                try {
+                    loadingTask.get();
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                } catch (ExecutionException e) {
+                    LOGGER.error("Loading an incremental file failed", e.getCause());
+                }
+            }
             // waits for the queued lookups, and never fails the Crossref update
             openAccessUpdater.close();
         }
@@ -236,10 +252,8 @@ public class IncrementalLoaderTask implements Runnable {
         // possibly update with the lastest indexed date obtained from this file
         metadataLookup.setLastIndexed(LocalDateTime.now());  
 
-        // waiting that no more loading and no more indexing take place to optionally clean the
-        // directory of incremental files
-        // note: rather than managing termination of threads, we look at storage/index size
-        // for convenience
+        // the loading is done above; waiting that no more indexing takes place to optionally
+        // clean the directory of incremental files
         MetadataMatching metadataMatching = 
             MetadataMatching.getInstance(this.configuration, this.metadataLookup, null);
 

--- a/src/test/java/com/scienceminer/glutton/configuration/LookupConfigurationElasticTest.java
+++ b/src/test/java/com/scienceminer/glutton/configuration/LookupConfigurationElasticTest.java
@@ -1,0 +1,68 @@
+package com.scienceminer.glutton.configuration;
+
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+import io.dropwizard.configuration.ConfigurationValidationException;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+/**
+ * The Elasticsearch block of the configuration, read the way the service reads it.
+ */
+public class LookupConfigurationElasticTest {
+
+    private static LookupConfiguration load(String yaml) throws Exception {
+        YamlConfigurationFactory<LookupConfiguration> factory = new YamlConfigurationFactory<>(
+                LookupConfiguration.class, Validators.newValidator(), Jackson.newObjectMapper(), "dw");
+        ConfigurationSourceProvider source =
+                path -> new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+        return factory.build(source, "glutton.yml");
+    }
+
+    @Test
+    public void elasticBlock_shouldHaveTimeoutsAndBulkConcurrencyByDefault() throws Exception {
+        LookupConfiguration configuration = load("elastic:\n  host: localhost:9200\n  index: glutton\n");
+
+        assertThat(configuration.getElastic().getConnectTimeout(), is(30));
+        assertThat(configuration.getElastic().getSocketTimeout(), is(120));
+        assertThat(configuration.getElastic().getMaxConcurrentBulks(), is(4));
+    }
+
+    @Test
+    public void elasticBlock_shouldTakeTheConfiguredValues() throws Exception {
+        LookupConfiguration configuration = load("elastic:\n  host: localhost:9200\n  index: glutton\n"
+                + "  connectTimeout: 10\n  socketTimeout: 600\n  maxConcurrentBulks: 2\n");
+
+        assertThat(configuration.getElastic().getConnectTimeout(), is(10));
+        assertThat(configuration.getElastic().getSocketTimeout(), is(600));
+        assertThat(configuration.getElastic().getMaxConcurrentBulks(), is(2));
+    }
+
+    @Test
+    public void elasticBlock_shouldRefuseNoBulkAtAll() throws Exception {
+        try {
+            load("elastic:\n  host: localhost:9200\n  index: glutton\n  maxConcurrentBulks: 0\n");
+            fail("a pool of no thread would never index anything");
+        } catch (ConfigurationValidationException expected) {
+            assertThat(expected.getMessage().contains("maxConcurrentBulks"), is(true));
+        }
+    }
+
+    @Test
+    public void elasticBlock_shouldRefuseANoTimeout() throws Exception {
+        try {
+            load("elastic:\n  host: localhost:9200\n  index: glutton\n  socketTimeout: 0\n");
+            fail("waiting no time for an answer would fail every bulk");
+        } catch (ConfigurationValidationException expected) {
+            assertThat(expected.getMessage().contains("socketTimeout"), is(true));
+        }
+    }
+}

--- a/src/test/java/com/scienceminer/glutton/configuration/LookupConfigurationElasticTest.java
+++ b/src/test/java/com/scienceminer/glutton/configuration/LookupConfigurationElasticTest.java
@@ -57,6 +57,17 @@ public class LookupConfigurationElasticTest {
     }
 
     @Test
+    public void elasticBlock_shouldRefuseATimeoutThatOverflowsMilliseconds() throws Exception {
+        try {
+            // 2,147,484 seconds is the first value whose milliseconds do not fit an int
+            load("elastic:\n  host: localhost:9200\n  index: glutton\n  socketTimeout: 2147484\n");
+            fail("the client takes the timeout in milliseconds as an int");
+        } catch (ConfigurationValidationException expected) {
+            assertThat(expected.getMessage().contains("socketTimeout"), is(true));
+        }
+    }
+
+    @Test
     public void elasticBlock_shouldRefuseANoTimeout() throws Exception {
         try {
             load("elastic:\n  host: localhost:9200\n  index: glutton\n  socketTimeout: 0\n");

--- a/src/test/java/com/scienceminer/glutton/indexing/BulkRetryTest.java
+++ b/src/test/java/com/scienceminer/glutton/indexing/BulkRetryTest.java
@@ -36,6 +36,14 @@ public class BulkRetryTest {
         return operations;
     }
 
+    private static List<IndexOperation> createOnly(String... ids) {
+        List<IndexOperation> operations = new ArrayList<>();
+        for (String id : ids) {
+            operations.add(new IndexOperation(id, new MetadataObj(), true));
+        }
+        return operations;
+    }
+
     private static List<String> ids(List<IndexOperation> operations) {
         return operations.stream().map(op -> op.id).collect(Collectors.toList());
     }
@@ -126,8 +134,36 @@ public class BulkRetryTest {
         Outcome outcome = index(sender, operations("a", "b"));
 
         assertThat(outcome.indexed, is(0));
-        assertThat(outcome.failed, is(2));
+        // not refused, never taken: what a later run can still bring in
+        assertThat(outcome.unsent, is(2));
+        assertThat(outcome.failed, is(0));
         assertThat(sender.sent, hasSize(BulkRetry.MAX_ATTEMPTS));
+    }
+
+    @Test
+    public void alreadyThere_shouldBeSkippedWhenNotToBeReplaced() throws Exception {
+        ScriptedSender sender = new ScriptedSender(response(
+                acked("a"),
+                refused("b", 409, "version_conflict_engine_exception")));
+
+        Outcome outcome = index(sender, createOnly("a", "b"));
+
+        assertThat(outcome.indexed, is(1));
+        assertThat(outcome.skipped, is(1));
+        assertThat(outcome.failed, is(0));
+        assertThat(sender.sent, hasSize(1));
+    }
+
+    @Test
+    public void conflict_shouldStillBeAFailureWhenReplacing() throws Exception {
+        // an index operation does not conflict; a 409 there is something else and is not hidden
+        ScriptedSender sender = new ScriptedSender(response(
+                refused("a", 409, "version_conflict_engine_exception")));
+
+        Outcome outcome = index(sender, operations("a"));
+
+        assertThat(outcome.skipped, is(0));
+        assertThat(outcome.failed, is(1));
     }
 
     @Test
@@ -176,7 +212,9 @@ public class BulkRetryTest {
         Outcome outcome = index(sender, operations("a", "b"));
 
         assertThat(outcome.indexed, is(0));
+        // the cluster answered and said no: refused, not unsent
         assertThat(outcome.failed, is(2));
+        assertThat(outcome.unsent, is(0));
         assertThat(sender.sent, hasSize(1));
     }
 

--- a/src/test/java/com/scienceminer/glutton/indexing/BulkRetryTest.java
+++ b/src/test/java/com/scienceminer/glutton/indexing/BulkRetryTest.java
@@ -1,0 +1,194 @@
+package com.scienceminer.glutton.indexing;
+
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.ErrorCause;
+import co.elastic.clients.elasticsearch._types.ErrorResponse;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.OperationType;
+import com.scienceminer.glutton.indexing.BulkRetry.IndexOperation;
+import com.scienceminer.glutton.indexing.BulkRetry.Outcome;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * The retry logic of one bulk, driven with hand-made Elasticsearch answers so that no cluster is
+ * needed. The pause between attempts is set to nothing.
+ */
+public class BulkRetryTest {
+
+    private static List<IndexOperation> operations(String... ids) {
+        List<IndexOperation> operations = new ArrayList<>();
+        for (String id : ids) {
+            operations.add(new IndexOperation(id, new MetadataObj()));
+        }
+        return operations;
+    }
+
+    private static List<String> ids(List<IndexOperation> operations) {
+        return operations.stream().map(op -> op.id).collect(Collectors.toList());
+    }
+
+    private static BulkResponseItem acked(String id) {
+        return BulkResponseItem.of(i -> i.index("glutton").id(id).status(201).operationType(OperationType.Index));
+    }
+
+    private static BulkResponseItem refused(String id, int status, String type) {
+        return BulkResponseItem.of(i -> i.index("glutton").id(id).status(status).operationType(OperationType.Index)
+                .error(ErrorCause.of(e -> e.type(type).reason("because"))));
+    }
+
+    private static BulkResponse response(BulkResponseItem... items) {
+        boolean errors = Arrays.stream(items).anyMatch(item -> item.error() != null);
+        return BulkResponse.of(b -> b.errors(errors).took(1).items(Arrays.asList(items)));
+    }
+
+    private static BulkResponse allAcked(List<IndexOperation> operations) {
+        return response(operations.stream().map(op -> acked(op.id)).toArray(BulkResponseItem[]::new));
+    }
+
+    private static ElasticsearchException clusterError(int status) {
+        return new ElasticsearchException("bulk", ErrorResponse.of(r -> r.status(status)
+                .error(ErrorCause.of(e -> e.type("some_exception").reason("cluster said no")))));
+    }
+
+    /** Records what was sent on each attempt and answers from a script. */
+    private static class ScriptedSender implements BulkRetry.BulkSender {
+        final List<List<String>> sent = new ArrayList<>();
+        private final List<Object> script;
+
+        ScriptedSender(Object... script) {
+            this.script = new ArrayList<>(Arrays.asList(script));
+        }
+
+        @Override
+        public BulkResponse send(List<IndexOperation> operations) throws IOException {
+            sent.add(ids(operations));
+            Object next = script.isEmpty() ? "ack" : script.remove(0);
+            if (next instanceof IOException) {
+                throw (IOException) next;
+            }
+            if (next instanceof ElasticsearchException) {
+                throw (ElasticsearchException) next;
+            }
+            if (next instanceof BulkResponse) {
+                return (BulkResponse) next;
+            }
+            return allAcked(operations);
+        }
+    }
+
+    private static Outcome index(ScriptedSender sender, List<IndexOperation> operations) throws InterruptedException {
+        return new BulkRetry(sender, 0).index(operations);
+    }
+
+    @Test
+    public void allAcknowledged_shouldBeSentOnce() throws Exception {
+        ScriptedSender sender = new ScriptedSender();
+
+        Outcome outcome = index(sender, operations("a", "b", "c"));
+
+        assertThat(outcome.indexed, is(3));
+        assertThat(outcome.failed, is(0));
+        assertThat(sender.sent, hasSize(1));
+    }
+
+    @Test
+    public void timeout_shouldSendTheWholeBulkAgain() throws Exception {
+        ScriptedSender sender = new ScriptedSender(new SocketTimeoutException("30,000 milliseconds timeout"),
+                new SocketTimeoutException("again"));
+
+        Outcome outcome = index(sender, operations("a", "b"));
+
+        assertThat(outcome.indexed, is(2));
+        assertThat(outcome.failed, is(0));
+        assertThat(sender.sent, hasSize(3));
+        assertThat(sender.sent.get(2), contains("a", "b"));
+    }
+
+    @Test
+    public void neverAnswering_shouldGiveUpAfterTheLastAttempt() throws Exception {
+        Object[] script = new Object[BulkRetry.MAX_ATTEMPTS + 3];
+        Arrays.fill(script, new IOException("connection refused"));
+        ScriptedSender sender = new ScriptedSender(script);
+
+        Outcome outcome = index(sender, operations("a", "b"));
+
+        assertThat(outcome.indexed, is(0));
+        assertThat(outcome.failed, is(2));
+        assertThat(sender.sent, hasSize(BulkRetry.MAX_ATTEMPTS));
+    }
+
+    @Test
+    public void rejectedItems_shouldBeTheOnlyOnesSentAgain() throws Exception {
+        ScriptedSender sender = new ScriptedSender(response(
+                acked("a"),
+                refused("b", 429, "es_rejected_execution_exception"),
+                acked("c"),
+                refused("d", 429, "es_rejected_execution_exception")));
+
+        Outcome outcome = index(sender, operations("a", "b", "c", "d"));
+
+        assertThat(outcome.indexed, is(4));
+        assertThat(outcome.failed, is(0));
+        assertThat(sender.sent, hasSize(2));
+        assertThat(sender.sent.get(1), contains("b", "d"));
+    }
+
+    @Test
+    public void refusedForGood_shouldNotBeSentAgain() throws Exception {
+        ScriptedSender sender = new ScriptedSender(response(
+                acked("a"),
+                refused("b", 400, "mapper_parsing_exception")));
+
+        Outcome outcome = index(sender, operations("a", "b"));
+
+        assertThat(outcome.indexed, is(1));
+        assertThat(outcome.failed, is(1));
+        assertThat(sender.sent, hasSize(1));
+    }
+
+    @Test
+    public void busyCluster_shouldBeRetried() throws Exception {
+        ScriptedSender sender = new ScriptedSender(clusterError(503), clusterError(429));
+
+        Outcome outcome = index(sender, operations("a"));
+
+        assertThat(outcome.indexed, is(1));
+        assertThat(sender.sent, hasSize(3));
+    }
+
+    @Test
+    public void badRequest_shouldFailTheBulkAtOnce() throws Exception {
+        ScriptedSender sender = new ScriptedSender(clusterError(400));
+
+        Outcome outcome = index(sender, operations("a", "b"));
+
+        assertThat(outcome.indexed, is(0));
+        assertThat(outcome.failed, is(2));
+        assertThat(sender.sent, hasSize(1));
+    }
+
+    @Test
+    public void mismatchedAnswer_shouldSendTheBulkAgain() throws Exception {
+        // one item for two documents: nothing can be paired, so both go again
+        ScriptedSender sender = new ScriptedSender(response(acked("a")));
+
+        Outcome outcome = index(sender, operations("a", "b"));
+
+        assertThat(outcome.indexed, is(2));
+        assertThat(sender.sent, hasSize(2));
+        assertThat(sender.sent.get(1), contains("a", "b"));
+    }
+}


### PR DESCRIPTION
During the gap update the records are indexed in Elasticsearch by asynchronous bulk requests, one per batch, with the client's default 30s socket timeout, no cap on how many are in flight and no retry. On a busy cluster the bulks pile up, time out and are dropped: the records are in the storage but not in the index, the failure is only visible as a stack trace in the log, and the callback then dereferences the null response. The loading commands also exit while bulks are still in flight, losing the last ones (#111).

The async indexer now runs the bulks on a small pool of daemon threads, elastic.maxConcurrentBulks at a time, and holds the storing side back when as many again are waiting. Each bulk is sent again on a timeout or on a 429/503 answer, and only the items Elasticsearch rejected are sent again on a partial rejection, with a growing pause and a bounded number of attempts. Documents refused for good are counted as failed and their reason logged. The indexing clients take their connect and socket timeouts from the configuration, 30s and 120s by default. The load commands wait for the pending bulks before they exit and report how many records were indexed and how many were not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Elasticsearch connection and socket timeouts.
  * Added a limit for concurrent bulk indexing requests.
  * Added asynchronous bulk indexing with retries for temporary failures.
  * Loading commands now wait for indexing to finish and report indexed or failed records.
* **Documentation**
  * Documented indexing during data loading, retry behavior, monitoring counters, and index rebuilding.
* **Bug Fixes**
  * Improved handling of Elasticsearch timeouts, busy clusters, and rejected bulk items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->